### PR TITLE
feat: add 'dont_center' option

### DIFF
--- a/doc/remember.txt
+++ b/doc/remember.txt
@@ -96,6 +96,16 @@ g:remember_open_folds                                  *g:remember_open_folds*
 
         let g:remember_open_folds = true
 
+------------------------------------------------------------------------------
+g:remember_dont_center                                *g:remember_dont_center*
+
+    Disable screen centering when restoring cursor position.
+
+    Default: false                                                           ~
+
+    Example: >
+
+        let g:remember_dont_center = true
 ==============================================================================
  4. CHANGELOG                                             *remember-changelog*
 

--- a/lua/remember.lua
+++ b/lua/remember.lua
@@ -19,6 +19,7 @@ local config = {
   ignore_filetype = { "gitcommit", "gitrebase", "svn", "hgcommit" },
   ignore_buftype = { "quickfix", "nofile", "help" },
   open_folds = true,
+  dont_center = false,
 }
 
 function M.setup(options)
@@ -32,6 +33,10 @@ function M.setup(options)
 
   if options["open_folds"] then
     config["open_folds"] = options["open_folds"]
+  end
+
+  if options["dont_center"] then
+    config["dont_center"] = options["dont_center"]
   end
 end
 
@@ -62,8 +67,9 @@ function set_cursor_position()
   -- then continue
   if row > 0 and row <= api.nvim_buf_line_count(0) then
     -- If the last row is visible within this window, like in a very short
-    -- file, just set the cursor position to the saved position
-    if api.nvim_buf_line_count(0) == fn.line("w$") then
+    -- file, or user requested us not centering the screen, just set the cursor
+    -- position to the saved position
+    if api.nvim_buf_line_count(0) == fn.line("w$") or config["dont_center"] then
       api.nvim_win_set_cursor(0, cursor_position)
 
       -- If we're in the middle of the file, set the cursor position and center


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Add a "dont_center" option to disable screen centering

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

User might want to save not just cursor position but screen position as well.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```lua
require'remember'.setup{
    dont_center = true;
}
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
