### PR TITLE
docs: add Lazy.nvim usage snippet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ use({ 'vladdoster/remember.nvim', config = [[ require('remember') ]] })
 }
 ```
 
+### vim.pack
+
+vim.pack.add({'https://github.com/vladdoster/remember.nvim'})
+require("remember").setup({})
+
 For the full documentation, see [remember.txt](doc/remember.txt).
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Uses new Neovim `0.7` Lua `vim.nvim.create_autocmd` function.
 use({ 'vladdoster/remember.nvim', config = [[ require('remember') ]] })
 ```
 
+### Lazy.nvim
+
+```Lua
+-- Using Lazy.nvim
+{
+  'vladdoster/remember.nvim',
+  opts = {},
+}
+```
+
 For the full documentation, see [remember.txt](doc/remember.txt).
 
 ## Testing


### PR DESCRIPTION
## Summary
- Adds Lazy.nvim configuration example to README alongside existing Packer example
- Uses `opts = {}` pattern which automatically calls `require('remember').setup()`