### PR TITLE
ci: Add write permissions for issues in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The GitHub API treats PR comments as issues comments, requiring the issues: write permission to create or update them through github.rest.issues.createComment() and github.rest.issues.updateComment().

This permission change will allow the github-script action to successfully post the coverage report comment to the pull request.